### PR TITLE
cleanup extra config files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,14 +2,16 @@
 - fail: msg="This role requires 'loggly.token'"
   when: loggly.token | trim == ''
 
-- name: "Install rsyslog 8 for $InputFileName wilcard paths"
-  apt_repository: repo="{{ loggly.rsyslog_ppa }}"
+- include: v8.yml
   when: ansible_distribution == "Ubuntu" and loggly.rsyslog_version|int > 7
+
+- include: v7.yml
+  when: loggly.rsyslog_version|int < 8
 
 - apt: name={{ item }} update_cache=yes cache_valid_time=3600
   with_items:
+    - rsyslog
     - rsyslog-gnutls
-    - wget
 
 - name: Create cerfiticates folder If It Does Not Exist
   file: path={{ loggly.certificate_dest }} state=directory
@@ -18,10 +20,17 @@
   get_url: url={{ loggly.certificate_url }} dest={{ loggly.certificate_dest }}{{ loggly.certificate_file }}
   ignore_errors: yes
 
+- name: Ensure wget is installed until SNI is supported
+  apt: name=wget update_cache=yes cache_valid_time=3600
+
 - name: Use wget cause Python 2.7.6 doesn't support https://en.wikipedia.org/wiki/Server_Name_Indication
   command: wget -O {{ loggly.certificate_dest }}{{ loggly.certificate_file }} {{ loggly.certificate_url }}
   notify:
     - restart_rsyslog
+
+# using shell until file: state=absent works the same as below
+- name: Cleanup files that may have been left by other installations
+  shell: rm -f /etc/rsyslog.d/*-loggly-*
 
 - name: Add Rsyslog configuration file
   template: src="{{ item }}" dest="/etc/rsyslog.d/{{ item }}" owner=root group=root

--- a/tasks/v8.yml
+++ b/tasks/v8.yml
@@ -1,0 +1,2 @@
+- name: Install rsyslog v8 which provides support for $InputFileName wildcard paths
+  apt_repository: repo="{{ loggly.rsyslog_ppa }}"


### PR DESCRIPTION
:elephant:
* We may have extra config if we were changing stuff in that directory,
delete what's there so we have a clean state (this may be a bad default
behaviour to choose)
* Couldn't use file: state=absent because it doesn't support wildcards
and it fails if the files aren't there
* also moved version 8 stuff into it's own file