### PR TITLE
Disable the $KLogPermitNonKernelFacility Option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,9 @@
   notify:
     - restart_rsyslog
 
+- name: Disable $KLogPermitNonKernelFacility configuration (this option is deprecated)
+  lineinfile: dest=/etc/rsyslog.conf state=absent regexp='^\$KLogPermitNonKernelFacility'
+
 # using shell until file: state=absent works the same as below
 - name: Cleanup files that may have been left by other installations
   shell: rm -f /etc/rsyslog.d/*-loggly-*


### PR DESCRIPTION
:elephant:
* Rsyslog 8.16 on ubuntu 16.04 ships with an incorrect configuration
  option that is for older version of rsyslog.
* Modify the role to remove this configuration option if it is
  detected.
SEE:https://lists.launchpad.net/touch-packages/msg126911.html