### PR TITLE
We'll need to scrub health_check from rails-y logs as well

### DIFF
--- a/templates/22-loggly-application.conf
+++ b/templates/22-loggly-application.conf
@@ -21,6 +21,7 @@ $DefaultNetstreamDriverCAFile {{ loggly.certificate_dest }}{{ loggly.certificate
   $InputFilePersistStateInterval 20000
   $InputRunFileMonitor
 
+  if $msg contains 'health_check' then ~
   if $programname == '{{ loggly.application.tag }}{{ loop.index }}' then @@logs-01.loggly.com:6514;LogglyFormat{{ loggly.application.tag }}
   if $programname == '{{ loggly.application.tag }}{{ loop.index }}' then ~
 


### PR DESCRIPTION
silencer isn't working across the board. looks like there are issues specific to automotive and unicorn logging that I haven't been able to resolve on the unicorn side yet, so in the meantime, this'll let loggly do its job and resolve the current issue.

🐘 