### PR TITLE
add logrotate from amaabca.common

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ loggly:
     error_logs:
       - /var/log/nginx/error.log
   action_queue_max_disk_space: 250m
+  logrotate: true

--- a/tasks/logrotate.yml
+++ b/tasks/logrotate.yml
@@ -1,0 +1,11 @@
+- name: Install logrotate
+  apt: pkg=logrotate state=present
+
+- name: update nginx logrotate config
+  action: template src=logrotate.nginx dest=/etc/logrotate.d/nginx owner=root group=root
+
+- name: update app logrotate config
+  action: template src=logrotate.rails dest=/etc/logrotate.d/rails owner=root group=root
+
+- name: add rotation to daily cron
+  action: template src=logrotate.cron dest=/etc/cron.daily/logrotate owner=root group=root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
 - include: v7.yml
   when: loggly.rsyslog_version|int < 8
 
+- include: logrotate.yml
+  when: loggly.logrotate
+
 - apt: name={{ item }} update_cache=yes cache_valid_time=3600
   with_items:
     - rsyslog

--- a/templates/logrotate.cron
+++ b/templates/logrotate.cron
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+/usr/sbin/logrotate /etc/logrotate.conf
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit 0

--- a/templates/logrotate.nginx
+++ b/templates/logrotate.nginx
@@ -1,0 +1,17 @@
+# {{ ansible_managed }}
+/var/log/nginx/*.log {
+  daily
+  missingok
+  rotate 14
+  compress
+  delaycompress
+  notifempty
+  create 640 www-data adm
+  sharedscripts
+  postrotate
+    [ -f /var/run/nginx.pid ] && kill -USR1 $(cat /var/run/nginx.pid)
+    service rsyslog stop
+    rm /var/spool/rsyslog/imfile-state*
+    service rsyslog start
+  endscript
+}

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+/srv/**/log/*.log {
+  su root root
+  daily
+  size 50M
+  rotate 3
+  missingok
+  notifempty
+  delaycompress
+  copytruncate
+  postrotate
+    service rsyslog stop
+    rm /var/spool/rsyslog/imfile-state*
+    service rsyslog start
+  endscript
+}


### PR DESCRIPTION
- extracted from https://github.com/amaabca/ansible-common
- since our logrotation is coupled to rsyslog now, move them into the
  same role and add enabling it as optional (default to installing it
  though)
- includes postrotation command to restart rsyslog
- fix a few ansible-lint errors

See Also:
- http://kb.monitorware.com/rsyslog-imfile-module-breaks-when-files-are-truncated-t10891.html
- https://www.loggly.com/docs/log-rotate/