### PR TITLE
match file patterns on Trusty and Xenial

### DIFF
--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-/srv/**/log/*.log {
+/var/log/rails/*.log {
   su root root
   daily
   size 50M


### PR DESCRIPTION
- because `/srv/**/log/*.log` glob doesn't match logs on Ubuntu 16.04
  (Xenial), change to a version that works in both distributions (14.04
    and 16.04)