### PR TITLE
TechDBT-1212 - Log Duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ secrets:
 Dependencies
 ------------
 
-All configuration was done with rsyslogd 7.4.4.
+All configuration was done with rsyslogd 8.23.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ secrets:
 Dependencies
 ------------
 
-All configuration was done with rsyslogd 8.23.
+All configuration was done with rsyslogd 8.24.
 
 Example Playbook
 ----------------
@@ -37,6 +37,12 @@ How to include this role:
   roles:
     - loggly_tls
 ```
+
+Usage With Unicorn
+------------------
+
+By default, this playbook assumes that you are running [Unicorn](http://unicorn.bogomips.org) for an application server.
+To disable this functionality, set the `loggly.refresh_unicorn` variable to `false`.
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ loggly:
       - /var/log/nginx/error.log
   action_queue_max_disk_space: 250m
   logrotate: true
+  refresh_unicorn: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ loggly:
   certificate_url: https://logdog.loggly.com/media/logs-01.loggly.com_sha12.crt
   certificate_file: logs-01.loggly.com_sha12.crt
   certificate_dest: /etc/rsyslog.d/keys/ca.d/
-  rsyslog_version: 8
+  rsyslog_ppa: ppa:adiscon/v8-stable
   application:
     tag: Rails
     logs: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ loggly:
   certificate_file: logs-01.loggly.com_sha12.crt
   certificate_dest: /etc/rsyslog.d/keys/ca.d/
   rsyslog_version: 8
-  rsyslog_ppa: ppa:adiscon/v8-stable
   application:
     tag: Rails
     logs: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ loggly:
   certificate_url: https://logdog.loggly.com/media/logs-01.loggly.com_sha12.crt
   certificate_file: logs-01.loggly.com_sha12.crt
   certificate_dest: /etc/rsyslog.d/keys/ca.d/
-  rsyslog_ppa: ppa:adiscon/v8-stable
+  rsyslog_apt_repository: ppa:adiscon/v8-stable
   application:
     tag: Rails
     logs: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: restart_rsyslog
-  service: name=rsyslog state=restarted
+  service:
+    name: rsyslog
+    state: restarted
   notify: verify_rsylog_config
 
 - name: verify_rsylog_config

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+    - xenial
   galaxy_tags:
     - rsyslog
     - loggly

--- a/tasks/loggly.yml
+++ b/tasks/loggly.yml
@@ -1,12 +1,19 @@
-- name: Create cerfiticates folder If It Does Not Exist
-  file: path={{ loggly.certificate_dest }} state=directory
+- name: Create cerfiticates folder if it does not exist
+  file:
+    path: "{{ loggly.certificate_dest }}"
+    state: directory
 
 - name: Install loggly certificate bundle once https://en.wikipedia.org/wiki/Server_Name_Indication is supported
-  get_url: url={{ loggly.certificate_url }} dest={{ loggly.certificate_dest }}{{ loggly.certificate_file }}
+  get_url:
+    url: "{{ loggly.certificate_url }}"
+    dest: "{{ loggly.certificate_dest }}{{ loggly.certificate_file }}"
   ignore_errors: yes
 
 - name: Ensure wget is installed until SNI is supported
-  apt: name=wget update_cache=yes cache_valid_time=3600
+  apt:
+    name: wget
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: Use wget cause Python 2.7.6 doesn't support https://en.wikipedia.org/wiki/Server_Name_Indication
   command: wget -O {{ loggly.certificate_dest }}{{ loggly.certificate_file }} {{ loggly.certificate_url }}
@@ -18,7 +25,11 @@
   shell: rm -f /etc/rsyslog.d/*-loggly-*
 
 - name: Add Rsyslog configuration file
-  template: src="{{ item }}" dest="/etc/rsyslog.d/{{ item }}" owner=root group=root
+  template:
+    src: "{{ item }}"
+    dest: "/etc/rsyslog.d/{{ item }}"
+    owner: root
+    group: root
   with_items:
     - 21-loggly-base.conf
     - 22-loggly-application.conf

--- a/tasks/loggly.yml
+++ b/tasks/loggly.yml
@@ -1,0 +1,28 @@
+- name: Create cerfiticates folder If It Does Not Exist
+  file: path={{ loggly.certificate_dest }} state=directory
+
+- name: Install loggly certificate bundle once https://en.wikipedia.org/wiki/Server_Name_Indication is supported
+  get_url: url={{ loggly.certificate_url }} dest={{ loggly.certificate_dest }}{{ loggly.certificate_file }}
+  ignore_errors: yes
+
+- name: Ensure wget is installed until SNI is supported
+  apt: name=wget update_cache=yes cache_valid_time=3600
+
+- name: Use wget cause Python 2.7.6 doesn't support https://en.wikipedia.org/wiki/Server_Name_Indication
+  command: wget -O {{ loggly.certificate_dest }}{{ loggly.certificate_file }} {{ loggly.certificate_url }}
+  notify:
+    - restart_rsyslog
+
+# using shell until file: state=absent works the same as below
+- name: Cleanup files that may have been left by other installations
+  shell: rm -f /etc/rsyslog.d/*-loggly-*
+
+- name: Add Rsyslog configuration file
+  template: src="{{ item }}" dest="/etc/rsyslog.d/{{ item }}" owner=root group=root
+  with_items:
+    - 21-loggly-base.conf
+    - 22-loggly-application.conf
+    - 22-loggly-nginx.conf
+    - 23-loggly-rsyslog_tls.conf
+  notify:
+    - restart_rsyslog

--- a/tasks/logrotate.yml
+++ b/tasks/logrotate.yml
@@ -1,11 +1,25 @@
 - name: Install logrotate
-  apt: pkg=logrotate state=present
+  apt:
+    pkg: logrotate
+    state: present
 
 - name: update nginx logrotate config
-  action: template src=logrotate.nginx dest=/etc/logrotate.d/nginx owner=root group=root
+  template:
+    src: logrotate.nginx
+    dest: /etc/logrotate.d/nginx
+    owner: root
+    group: root
 
 - name: update app logrotate config
-  action: template src=logrotate.rails dest=/etc/logrotate.d/rails owner=root group=root
+  template:
+    src: logrotate.rails
+    dest: /etc/logrotate.d/rails
+    owner: root
+    group: root
 
 - name: add rotation to daily cron
-  action: template src=logrotate.cron dest=/etc/cron.daily/logrotate owner=root group=root
+  template:
+    src: logrotate.cron
+    dest: /etc/cron.daily/logrotate
+    owner: root
+    group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,48 +2,9 @@
 - fail: msg="This role requires 'loggly.token'"
   when: loggly.token | trim == ''
 
-- include: v8.yml
-  when: ansible_distribution == "Ubuntu" and loggly.rsyslog_version|int > 7
-
-- include: v7.yml
-  when: loggly.rsyslog_version|int < 8
-
 - include: logrotate.yml
   when: loggly.logrotate
 
-- apt: name={{ item }} update_cache=yes cache_valid_time=3600
-  with_items:
-    - rsyslog
-    - rsyslog-gnutls
+- include: rsyslog.yml
 
-- name: Create cerfiticates folder If It Does Not Exist
-  file: path={{ loggly.certificate_dest }} state=directory
-
-- name: Install loggly certificate bundle once https://en.wikipedia.org/wiki/Server_Name_Indication is supported
-  get_url: url={{ loggly.certificate_url }} dest={{ loggly.certificate_dest }}{{ loggly.certificate_file }}
-  ignore_errors: yes
-
-- name: Ensure wget is installed until SNI is supported
-  apt: name=wget update_cache=yes cache_valid_time=3600
-
-- name: Use wget cause Python 2.7.6 doesn't support https://en.wikipedia.org/wiki/Server_Name_Indication
-  command: wget -O {{ loggly.certificate_dest }}{{ loggly.certificate_file }} {{ loggly.certificate_url }}
-  notify:
-    - restart_rsyslog
-
-- name: Disable $KLogPermitNonKernelFacility configuration (this option is deprecated)
-  lineinfile: dest=/etc/rsyslog.conf state=absent regexp='^\$KLogPermitNonKernelFacility'
-
-# using shell until file: state=absent works the same as below
-- name: Cleanup files that may have been left by other installations
-  shell: rm -f /etc/rsyslog.d/*-loggly-*
-
-- name: Add Rsyslog configuration file
-  template: src="{{ item }}" dest="/etc/rsyslog.d/{{ item }}" owner=root group=root
-  with_items:
-    - 21-loggly-base.conf
-    - 22-loggly-application.conf
-    - 22-loggly-nginx.conf
-    - 23-loggly-rsyslog_tls.conf
-  notify:
-    - restart_rsyslog
+- include: loggly.yml

--- a/tasks/rsyslog.yml
+++ b/tasks/rsyslog.yml
@@ -1,3 +1,15 @@
+- name: Purging previous Rsyslog versions
+  apt:
+    name: "{{ item }}"
+    state: absent
+    purge: yes
+    autoremove: yes
+    update_cache: yes
+    cache_valid_time: 0
+  with_items:
+    - rsyslog-gnutls
+    - rsyslog
+
 - name: Install Rsyslog custom repository for v8 on Ubuntu <= 14.04
   apt_repository:
     repo: "{{ loggly.rsyslog_apt_repository }}"
@@ -15,10 +27,11 @@
     name: "{{ item }}"
     state: latest
     update_cache: yes
-    cache_valid_time: 3600
+    force: yes
+    cache_valid_time: 0
   with_items:
-    - rsyslog
     - rsyslog-gnutls
+    - rsyslog
 
 - name: Disable $KLogPermitNonKernelFacility configuration (this option is deprecated)
   lineinfile:

--- a/tasks/rsyslog.yml
+++ b/tasks/rsyslog.yml
@@ -1,6 +1,14 @@
-- name: Install Rsyslog custom PPA for a consistent version
+- name: Install Rsyslog custom repository for v8 on Ubuntu <= 14.04
   apt_repository:
-    repo: "{{ loggly.rsyslog_ppa }}"
+    repo: "{{ loggly.rsyslog_apt_repository }}"
+    state: present
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version|float < 16.04
+
+- name: Cleanup older apt repositories on Ubuntu > 14.04
+  apt_repository:
+    repo: "{{ loggly.rsyslog_apt_repository }}"
+    state: absent
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version|float >= 16.04
 
 - name: Install Rsyslog with TLS
   apt:

--- a/tasks/rsyslog.yml
+++ b/tasks/rsyslog.yml
@@ -1,0 +1,13 @@
+- name: Install Rsyslog version 8 with TLS
+  apt:
+    name: "{{ item }}={{ loggly.rsyslog_version }}"
+    state: latest
+    update_cache: yes
+    upgrade: safe
+    cache_valid_time: 3600
+  with_items:
+    - rsyslog
+    - rsyslog-gnutls
+
+- name: Disable $KLogPermitNonKernelFacility configuration (this option is deprecated)
+  lineinfile: dest=/etc/rsyslog.conf state=absent regexp='^\$KLogPermitNonKernelFacility'

--- a/tasks/rsyslog.yml
+++ b/tasks/rsyslog.yml
@@ -1,13 +1,19 @@
-- name: Install Rsyslog version 8 with TLS
+- name: Install Rsyslog custom PPA for a consistent version
+  apt_repository:
+    repo: "{{ loggly.rsyslog_ppa }}"
+
+- name: Install Rsyslog with TLS
   apt:
-    name: "{{ item }}={{ loggly.rsyslog_version }}"
+    name: "{{ item }}"
     state: latest
     update_cache: yes
-    upgrade: safe
     cache_valid_time: 3600
   with_items:
     - rsyslog
     - rsyslog-gnutls
 
 - name: Disable $KLogPermitNonKernelFacility configuration (this option is deprecated)
-  lineinfile: dest=/etc/rsyslog.conf state=absent regexp='^\$KLogPermitNonKernelFacility'
+  lineinfile:
+    dest: /etc/rsyslog.conf
+    state: absent
+    regexp: '^\$KLogPermitNonKernelFacility'

--- a/tasks/v8.yml
+++ b/tasks/v8.yml
@@ -1,2 +1,0 @@
-- name: Install rsyslog v8 which provides support for $InputFileName wildcard paths
-  apt_repository: repo="{{ loggly.rsyslog_ppa }}"

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -2,12 +2,11 @@
 /var/log/rails/*.log {
   su root root
   daily
-  size 50M
   rotate 3
   missingok
   notifempty
   delaycompress
-  copytruncate
+  sharedscripts
   postrotate
     service rsyslog stop
     rm /var/spool/rsyslog/imfile-state*

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -9,7 +9,7 @@
   sharedscripts
   postrotate
     # Unicorn - reopen all logfiles
-    if [ {{ loggly.refresh_unicorn }} = true ]; then
+    if [ {{ loggly.refresh_unicorn }} = True ]; then
       master_pid=$(ps aux | grep '[u]nicorn master' | awk '{print $2}')
       kill -USR1 $master_pid
     fi

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -8,6 +8,12 @@
   delaycompress
   sharedscripts
   postrotate
+    # Unicorn - reopen all logfiles
+    if [ {{ loggly.refresh_unicorn }} = true ]; then
+      master_pid=$(ps aux | grep '[u]nicorn master' | awk '{print $2}')
+      kill -USR1 $master_pid
+    fi
+    # Restart Rsyslog - delete state for old files
     service rsyslog stop
     rm /var/spool/rsyslog/imfile-state*
     service rsyslog start


### PR DESCRIPTION
:elephant:

* We were seeing duplicates in loggly due to how we were handling `rsyslog` state files after a log rotation. We were simply deleting all state files which is okay if a new file is eventually made, but is not compatible with the `copytrucate` directive for logrotate.
* Furthermore, it was possible that some logfiles would not be rotated due to size, yet we would still delete rsyslog state.
* Remove size restrictions - non-empty log files will now always be rotated for simplicity.
* Don't use copytruncate - instead trigger a reopen of our application server's log files (unicorn) on rotation. This feature is enabled by default.
* To disable the unicorn reload, set the `loggly.refresh_unicorn` variable to `false`.