### PR TITLE
TECHDBT-1212 - Log Duplicates

### DIFF
--- a/templates/logrotate.nginx
+++ b/templates/logrotate.nginx
@@ -8,10 +8,13 @@
   notifempty
   create 640 www-data adm
   sharedscripts
+  firstaction
+    service rsyslog stop
+  endscript
   postrotate
     [ -f /var/run/nginx.pid ] && kill -USR1 $(cat /var/run/nginx.pid)
-    service rsyslog stop
-    rm /var/spool/rsyslog/imfile-state*
+  endscript
+  lastaction
     service rsyslog start
   endscript
 }

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -7,15 +7,19 @@
   notifempty
   delaycompress
   sharedscripts
+  firstaction
+    service rsyslog stop
+  endscript
   postrotate
     # Unicorn - reopen all logfiles
     if [ {{ loggly.refresh_unicorn }} = True ]; then
       master_pid=$(ps aux | grep '[u]nicorn master' | awk '{print $2}')
       kill -USR1 $master_pid
     fi
-    # Restart Rsyslog - delete state for old files
-    service rsyslog stop
+    # Delete Rsyslog state for the rotated files
     rm /var/spool/rsyslog/imfile-state*
+  endscript
+  lastaction
     service rsyslog start
   endscript
 }


### PR DESCRIPTION
:elephant:

* Tighten up the logrotate configuration files. Now only delete the
  rsyslog state files once (in one block).
* Use the `firstaction` and `lastaction` directives to control the
  rsyslog service state.