### PR TITLE
Increasing the rsyslog max message size

### DIFF
--- a/tasks/rsyslog.yml
+++ b/tasks/rsyslog.yml
@@ -38,3 +38,8 @@
     dest: /etc/rsyslog.conf
     state: absent
     regexp: '^\$KLogPermitNonKernelFacility'
+
+- name: Set a larger max message size
+  lineinfile:
+    dest: /etc/rsyslog.conf
+    line: '$MaxMessageSize 250k'


### PR DESCRIPTION
- One of our apps is generating ~210KB payloads, so this change will allow even our most cluttered responses to get into Loggly.

https://ama-digital.myjetbrains.com/youtrack/issue/INSGW-114
🐘 