### PR TITLE
Fix shoryuken logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Usage With Unicorn
 By default, this playbook assumes that you are running [Unicorn](http://unicorn.bogomips.org) for an application server.
 To disable this functionality, set the `loggly.refresh_unicorn` variable to `false`.
 
+Usage With Shoryuken
+------------------
+
+This playbook will also rotate [Shoryuken](https://github.com/phstc/shoryuken) logs.
+To enable this functionality, set the `loggly.refresh_shoryuken` variable to `true`.
+
 License
 -------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,4 @@ loggly:
   action_queue_max_disk_space: 250m
   logrotate: true
   refresh_unicorn: true
+  refresh_shoryuken: false

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -16,6 +16,10 @@
       master_pid=$(ps aux | grep '[u]nicorn master' | awk '{print $2}')
       kill -USR1 $master_pid
     fi
+    # Shoryuken - reopen all logfiles
+    if [ {{ loggly.refresh_shoryuken }} = True ]; then
+      service shoryuken restart
+    fi
     # Delete Rsyslog state for the rotated files
     rm /var/spool/rsyslog/imfile-state*
   endscript


### PR DESCRIPTION
* Because when log rotate happens the shoryuken service still was
pointing to the old file.
* Set the default to false becuase no all servers have shoryuken. the
servers that have can overwrite the default.
SEE: phstc/shoryuken#458