### PR TITLE
VSTS-105 - Server Rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ secrets:
 Dependencies
 ------------
 
-All configuration was done with rsyslogd 8.24.
+All configuration was done with rsyslogd v8.32.0.
 
 Example Playbook
 ----------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     versions:
     - trusty
     - xenial
+    - bionic
   galaxy_tags:
     - rsyslog
     - loggly

--- a/tasks/loggly.yml
+++ b/tasks/loggly.yml
@@ -3,28 +3,31 @@
     path: "{{ loggly.certificate_dest }}"
     state: directory
 
-- name: Install loggly certificate bundle once https://en.wikipedia.org/wiki/Server_Name_Indication is supported
+- name: Install Loggly Certificate Bundle
   get_url:
     url: "{{ loggly.certificate_url }}"
     dest: "{{ loggly.certificate_dest }}{{ loggly.certificate_file }}"
-  ignore_errors: yes
-
-- name: Ensure wget is installed until SNI is supported
-  apt:
-    name: wget
-    update_cache: yes
-    cache_valid_time: 3600
-
-- name: Use wget cause Python 2.7.6 doesn't support https://en.wikipedia.org/wiki/Server_Name_Indication
-  command: wget -O {{ loggly.certificate_dest }}{{ loggly.certificate_file }} {{ loggly.certificate_url }}
-  tags:
-   - cert
   notify:
     - restart_rsyslog
 
-# using shell until file: state=absent works the same as below
-- name: Cleanup files that may have been left by other installations
-  shell: rm -f /etc/rsyslog.d/*-loggly-*
+- name: Find Existing Loggly Artifacts
+  find:
+    paths: /etc/rsyslog.d
+    patterns: '*-loggly-*'
+  register: loggly_artifacts
+
+- name: Cleanup Existing Artifacts Left From Previous Installations
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ loggly_artifacts.files }}"
+
+- name: Ensure Application Logfiles Exist
+  file:
+    path: "{{ item }}"
+    state: touch
+    follow: yes
+  with_items: "{{ loggly.application.logs }}"
 
 - name: Add Rsyslog configuration file
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- fail: msg="This role requires 'loggly.token'"
+- fail:
+    msg: This role requires 'loggly.token'
   when: loggly.token | trim == ''
 
 - include: logrotate.yml

--- a/tasks/rsyslog.yml
+++ b/tasks/rsyslog.yml
@@ -1,14 +1,13 @@
 - name: Purging previous Rsyslog versions
   apt:
-    name: "{{ item }}"
+    name:
+      - rsyslog-gnutls
+      - rsyslog
     state: absent
     purge: yes
     autoremove: yes
     update_cache: yes
     cache_valid_time: 0
-  with_items:
-    - rsyslog-gnutls
-    - rsyslog
 
 - name: Install Rsyslog custom repository for v8 on Ubuntu <= 14.04
   apt_repository:
@@ -24,14 +23,13 @@
 
 - name: Install Rsyslog with TLS
   apt:
-    name: "{{ item }}"
+    name:
+      - rsyslog-gnutls
+      - rsyslog
     state: latest
     update_cache: yes
     force: yes
     cache_valid_time: 0
-  with_items:
-    - rsyslog-gnutls
-    - rsyslog
 
 - name: Disable $KLogPermitNonKernelFacility configuration (this option is deprecated)
   lineinfile:

--- a/templates/22-loggly-application.conf
+++ b/templates/22-loggly-application.conf
@@ -21,8 +21,8 @@ $DefaultNetstreamDriverCAFile {{ loggly.certificate_dest }}{{ loggly.certificate
   $InputFilePersistStateInterval 20000
   $InputRunFileMonitor
 
-  if $msg contains 'health_check' then ~
+  if $msg contains 'health_check' then stop
   if $programname == '{{ loggly.application.tag }}{{ loggly.application.environment }}' then @@logs-01.loggly.com:6514;LogglyFormat{{ loggly.application.tag }}
-  if $programname == '{{ loggly.application.tag }}{{ loggly.application.environment }}' then ~
+  if $programname == '{{ loggly.application.tag }}{{ loggly.application.environment }}' then stop
 
 {% endfor %}

--- a/templates/22-loggly-nginx.conf
+++ b/templates/22-loggly-nginx.conf
@@ -21,9 +21,9 @@ $DefaultNetstreamDriverCAFile {{ loggly.certificate_dest }}{{ loggly.certificate
   $InputFilePersistStateInterval 20000
   $InputRunFileMonitor
 
-  if $msg contains 'health_check' then ~
+  if $msg contains 'health_check' then stop
   if $programname == "{{ loggly.application.tag }}{{ loggly.application.environment }}" then @@logs-01.loggly.com:6514;LogglyFormatNginx
-  if $programname == "{{ loggly.application.tag }}{{ loggly.application.environment }}" then ~
+  if $programname == "{{ loggly.application.tag }}{{ loggly.application.environment }}" then stop
 {% endfor %}
 
 #Nginx Error files:
@@ -46,8 +46,8 @@ $DefaultNetstreamDriverCAFile {{ loggly.certificate_dest }}{{ loggly.certificate
   $InputFilePersistStateInterval 20000
   $InputRunFileMonitor
 
-  if $msg contains 'health_check' then ~
+  if $msg contains 'health_check' then stop
   if $programname == '{{ loggly.application.tag }}{{ loggly.application.environment }}' then @@logs-01.loggly.com:6514;LogglyFormatNginx
-  if $programname == '{{ loggly.application.tag }}{{ loggly.application.environment }}' then ~
+  if $programname == '{{ loggly.application.tag }}{{ loggly.application.environment }}' then stop
 
 {% endfor %}

--- a/templates/23-loggly-rsyslog_tls.conf
+++ b/templates/23-loggly-rsyslog_tls.conf
@@ -10,8 +10,8 @@ $ActionSendStreamDriverPermittedPeer *.loggly.com
 $template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [{{ loggly.token }}@41058 tag=\"RsyslogTLS\"] %msg%\n"
 
 #Ignore reporting iNodes
-if $msg contains 'iNodes/dev/' then ~
-if $msg contains 'iNodes/udev/' then ~
-if $msg contains 'iNodes/tmpfs/' then ~
+if $msg contains 'iNodes/dev/' then stop
+if $msg contains 'iNodes/udev/' then stop
+if $msg contains 'iNodes/tmpfs/' then stop
 # Send messages to Loggly over TCP using the template.
 *.* @@logs-01.loggly.com:6514;LogglyFormat


### PR DESCRIPTION
:elephant:

* Update ansible syntax to the YAML-style scheme.
* Don't install `wget` when we don't need it - instead, just
  use `get_url`.
* Fix deprecations when using the apt package to install/uninstall
  packages.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/105